### PR TITLE
Make interface `IComponentRenderer` public

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/IComponentRenderer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/IComponentRenderer.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {
-    internal interface IComponentRenderer
+    public interface IComponentRenderer
     {
         Task<IHtmlContent> RenderComponentAsync(
             ViewContext viewContext,


### PR DESCRIPTION
Make interface `IComponentRenderer` public so components can be rendered in normal C#/F# code without razor. This seems to be currently impossible without calling into internal types via reflection.

Summary of the changes (Less than 80 chars)
 - Change access modifier of `IComponentRenderer` from `internal` to `public`

Addresses #29120
